### PR TITLE
test(COD-7216): trigger IaC + SCA findings to validate status-check deep-link

### DIFF
--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -1,0 +1,30 @@
+# Test fixture for COD-7216: intentionally insecure IaC used to trigger new
+# FortiCNAPP IaC (Infrastructure as Code) violations on a pull request so the
+# status-check deep-link can be validated on DEV5. Do NOT deploy.
+
+# SSH open to the entire internet (0.0.0.0/0 on port 22) — critical IaC violation.
+resource "aws_security_group" "cod7216_open_ssh" {
+  name        = "cod7216-open-ssh"
+  description = "Test SG that allows SSH from anywhere"
+
+  ingress {
+    description = "SSH from anywhere"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Public, unencrypted S3 bucket — should flag public-access + encryption violations.
+resource "aws_s3_bucket" "cod7216_public_bucket" {
+  bucket = "cod7216-public-test-bucket"
+  acl    = "public-read"
+}

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -28,3 +28,5 @@ resource "aws_s3_bucket" "cod7216_public_bucket" {
   bucket = "cod7216-public-test-bucket"
   acl    = "public-read"
 }
+
+# COD-7216 rescan trigger

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -7,6 +7,7 @@ resource "aws_security_group" "cod7216_open_ssh" {
   name        = "cod7216-open-ssh"
   description = "Test SG that allows SSH from anywhere"
 
+
   ingress {
     description = "SSH from anywhere"
     from_port   = 22

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -8,6 +8,7 @@ resource "aws_security_group" "cod7216_open_ssh" {
   description = "Test SG that allows SSH from anywhere"
 
 
+
   ingress {
     description = "SSH from anywhere"
     from_port   = 22

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -9,6 +9,7 @@ resource "aws_security_group" "cod7216_open_ssh" {
 
 
 
+
   ingress {
     description = "SSH from anywhere"
     from_port   = 22

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -8,9 +8,6 @@ resource "aws_security_group" "cod7216_open_ssh" {
   description = "Test SG that allows SSH from anywhere"
 
 
-
-
-
   ingress {
     description = "SSH from anywhere"
     from_port   = 22

--- a/example/insecure_test.tf
+++ b/example/insecure_test.tf
@@ -9,6 +9,8 @@ resource "aws_security_group" "cod7216_open_ssh" {
 
 
 
+
+
   ingress {
     description = "SSH from anywhere"
     from_port   = 22

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ PyYAML==5.1
 Django==2.2.0
 requests==2.19.1
 urllib3==1.24.1
+# COD-7216 webhook retest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+# Test fixture for COD-7216: intentionally vulnerable Python dependencies used to
+# trigger new FortiCNAPP SCA (Software Composition Analysis) findings on a pull
+# request so the status-check deep-link can be validated on DEV5. Do NOT install.
+PyYAML==5.1
+Django==2.2.0
+requests==2.19.1
+urllib3==1.24.1


### PR DESCRIPTION
## Purpose

Test-only PR to validate the [COD-7216](https://lacework.atlassian.net/browse/COD-7216) status-check deep-link fix on DEV5. It intentionally introduces **new** IaC and SCA violations so FortiCNAPP posts a status check + PR comment for each, letting us confirm the status-check link now points to the exact assessment (matching the comment link).

## What it adds

**IaC** — `example/insecure_test.tf`
- `aws_security_group` allowing SSH (port 22) from `0.0.0.0/0`
- Public, unencrypted `aws_s3_bucket` (`acl = "public-read"`)

**SCA** — `requirements.txt` (pinned known-CVE versions)
- `PyYAML==5.1`, `Django==2.2.0`, `requests==2.19.1`, `urllib3==1.24.1`

## Expected

- **Lacework (IAC)** status check → deep-links to the exact assessment summary (`…/iac/assessments/repositories/{guid}/summary`)
- **Lacework (SCA)** status check → deep-links to the exact assessment (`…/applications/repositories/{repo}?uploadGuid=…`), matching the comment link

⚠️ Test fixtures only — do not merge/deploy.