### PR TITLE
test(COD-7036): SCA severity coercion (mixed-case filter + real findings)

### DIFF
--- a/.lacework/codesec.yaml
+++ b/.lacework/codesec.yaml
@@ -1,0 +1,9 @@
+# COD-7036 test: mixed-case sca.scan.severity. With the fix these coerce to
+# lowercase and the filter applies; without it the profile is rejected/miss-filtered.
+default:
+  sca:
+    enabled: true
+    scan:
+      severity:
+        - Critical
+        - High

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# COD-7036 test fixture: intentionally vulnerable Python deps to produce SCA findings. Do NOT install.
+PyYAML==5.1
+Django==2.2.0
+requests==2.19.1
+urllib3==1.24.1


### PR DESCRIPTION
Test PR for COD-7036 on DEV5.

Adds vulnerable Python deps (produce SCA findings) plus `.lacework/codesec.yaml` with mixed-case `sca.scan.severity: [Critical, High]`.

Expected with the fix deployed: the mixed-case severities coerce to `critical`/`high`, the filter is applied, and the SCA check reports the high+critical findings (not a broken/empty result and not the whole unfiltered set).